### PR TITLE
Update for Ruby 3.0

### DIFF
--- a/admin/app/controllers/workarea/api/admin/email_signups_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/email_signups_controller.rb
@@ -116,7 +116,7 @@ module Workarea
         def find_email_signup
           @email_signup = Email::Signup.find(params[:id])
         rescue Mongoid::Errors::DocumentNotFound
-          @email_signup = Email::Signup.find_by(email: URI.unescape(params[:id]))
+          @email_signup = Email::Signup.find_by(email: CGI.unescape(params[:id]))
         end
       end
     end

--- a/admin/app/controllers/workarea/api/admin/users_controller.rb
+++ b/admin/app/controllers/workarea/api/admin/users_controller.rb
@@ -298,7 +298,7 @@ module Workarea
         def find_user
           @user = User.find(params[:id])
         rescue Mongoid::Errors::DocumentNotFound
-          @user = User.find_by(email:  URI.unescape(params[:id]))
+          @user = User.find_by(email:  CGI.unescape(params[:id]))
         end
 
         def api_attributes_for(user)

--- a/admin/test/documentation/workarea/api/admin/email_signups_documentation_test.rb
+++ b/admin/test/documentation/workarea/api/admin/email_signups_documentation_test.rb
@@ -43,7 +43,7 @@ module Workarea
           signup = create_email_signup(email: 'test@workarea.com')
 
           record_request do
-            get admin_api.email_signup_path(URI.escape(signup.email, '+@.'))
+            get admin_api.email_signup_path(CGI.escape(signup.email).gsub('.', '%2E'))
             assert_equal(200, response.status)
           end
         end

--- a/admin/test/documentation/workarea/api/admin/users_documentation_test.rb
+++ b/admin/test/documentation/workarea/api/admin/users_documentation_test.rb
@@ -63,7 +63,7 @@ module Workarea
           user = create_user(email: 'test@workarea.com')
 
           record_request do
-            get admin_api.user_path(URI.escape(user.email, '+@.'))
+            get admin_api.user_path(CGI.escape(user.email).gsub('.', '%2E'))
             assert_equal(200, response.status)
           end
         end

--- a/admin/test/integration/workarea/api/admin/email_signups_integration_test.rb
+++ b/admin/test/integration/workarea/api/admin/email_signups_integration_test.rb
@@ -59,7 +59,7 @@ module Workarea
           result = JSON.parse(response.body)['email_signup']
           assert_equal(email_signup, Email::Signup.new(result))
 
-          get admin_api.email_signup_path(URI.escape(email_signup.email, '+@.'))
+          get admin_api.email_signup_path(CGI.escape(email_signup.email).gsub('.', '%2E'))
           result = JSON.parse(response.body)['email_signup']
           assert_equal(email_signup, Email::Signup.new(result))
         end

--- a/admin/test/integration/workarea/api/admin/users_integration_test.rb
+++ b/admin/test/integration/workarea/api/admin/users_integration_test.rb
@@ -78,7 +78,7 @@ module Workarea
           assert(result['password_digest'].blank?)
           assert_equal(user, User.new(result))
 
-          get admin_api.user_path(URI.escape(user.email, '+@.'))
+          get admin_api.user_path(CGI.escape(user.email).gsub('.', '%2E'))
           result = JSON.parse(response.body)['user']
           assert(result['password_digest'].blank?)
           assert_equal(user, User.new(result))

--- a/lib/workarea/api/version.rb
+++ b/lib/workarea/api/version.rb
@@ -1,5 +1,5 @@
 module Workarea
   module Api
-    VERSION = '4.6.0.pre'.freeze
+    VERSION = '4.6.0'.freeze
   end
 end


### PR DESCRIPTION
Replaces defunct URI methods and removes the PRE status from the version.